### PR TITLE
Fixed bug whereby region was ignored.

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,9 +56,9 @@ function S3Adapter() {
   let s3Options = {
     accessKeyId: options.accessKey,
     secretAccessKey: options.secretKey,
-    params: { Bucket: this._bucket }
+    params: { Bucket: this._bucket },
+    region: this._region
   };
-  AWS.config._region = this._region;
   this._s3Client = new AWS.S3(s3Options);
   this._hasBucket = false;
 }


### PR DESCRIPTION
I couldn't connect to a sydney S3 bucket, and triaged the issue to the fix below. This is in line with what the doco seems to say as well.

http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html

I tested that when this option is unset, the region defaults to us-east.