### PR TITLE
Adds option to specify an alternate baseUrl (e.g. CloudFront)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ And update your config / options
 var S3Adapter = require('parse-server-s3-adapter');
 
 var s3Adapter = new S3Adapter('accessKey',
-								'secretKey',
-								'bucket' , {
-								  region: 'us-east-1'
-									bucketPrefix: '',
-									directAccess: false,
-                  baseUrl: 'http://images.example.com'
-								});
+                  'secretKey',
+                  'bucket' , {
+                    region: 'us-east-1'
+                    bucketPrefix: '',
+                    directAccess: false,
+                    baseUrl: 'http://images.example.com'
+                  });
 
 var api = new ParseServer({
 	appId: 'my_app',
@@ -82,21 +82,21 @@ or with an options hash
 var S3Adapter = require('parse-server-s3-adapter');
 
 var s3Options = {
-	"accessKey": "accessKey",
-   	"secretKey": "secretKey",
-   	"bucket": "my_bucket",
-   	// optional:
-   	"region": 'us-east-1', // default value
-   	"bucketPrefix": '', // default value
-   	"directAccess": false, // default value
-    "baseUrl": null // default value
+  "accessKey": "accessKey",
+  "secretKey": "secretKey",
+  "bucket": "my_bucket",
+  // optional:
+  "region": 'us-east-1', // default value
+  "bucketPrefix": '', // default value
+  "directAccess": false, // default value
+  "baseUrl": null // default value
 }
 
 var s3Adapter = new S3Adapter(s3Options);
 
 var api = new ParseServer({
-	appId: 'my_app',
-	masterKey: 'master_key',
-	filesAdapter: s3Adapter
+  appId: 'my_app',
+  masterKey: 'master_key',
+  filesAdapter: s3Adapter
 })
 ```

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ parse-server adapter for AWS S3
       // optional:
       "region": 'us-east-1', // default value
       "bucketPrefix": '', // default value
-      "directAccess": false // default value
-    } 
+      "directAccess": false, // default value
+      "baseUrl": null // default value
+    }
   }
 }
 ```
@@ -59,12 +60,13 @@ And update your config / options
 ```
 var S3Adapter = require('parse-server-s3-adapter');
 
-var s3Adapter = new S3Adapter('accessKey', 
-								'secretKey', 
+var s3Adapter = new S3Adapter('accessKey',
+								'secretKey',
 								'bucket' , {
-								    region: 'us-east-1'
+								  region: 'us-east-1'
 									bucketPrefix: '',
-									directAccess: false
+									directAccess: false,
+                  baseUrl: 'http://images.example.com'
 								});
 
 var api = new ParseServer({
@@ -86,8 +88,9 @@ var s3Options = {
    	// optional:
    	"region": 'us-east-1', // default value
    	"bucketPrefix": '', // default value
-   	"directAccess": false // default value
-} 
+   	"directAccess": false, // default value
+    "baseUrl": null // default value
+}
 
 var s3Adapter = new S3Adapter(s3Options);
 
@@ -97,5 +100,3 @@ var api = new ParseServer({
 	filesAdapter: s3Adapter
 })
 ```
-
-

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function optionsFromArguments(args) {
     if (otherOptions) {
       options.bucketPrefix = otherOptions.bucketPrefix;
       options.directAccess = otherOptions.directAccess;
+      options.baseUrl = otherOptions.baseUrl;
     }
   } else {
     options = accessKeyOrOptions || {};
@@ -40,6 +41,7 @@ function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'bucketPrefix', 'S3_BUCKET_PREFIX', '');
   options = fromEnvironmentOrDefault(options, 'region', 'S3_REGION', DEFAULT_S3_REGION);
   options = fromEnvironmentOrDefault(options, 'directAccess', 'S3_DIRECT_ACCESS', false);
+  options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
   return options;
 }
 
@@ -52,6 +54,7 @@ function S3Adapter() {
   this._bucket = options.bucket;
   this._bucketPrefix = options.bucketPrefix;
   this._directAccess = options.directAccess;
+  this._baseUrl = options.baseUrl;
 
   let s3Options = {
     accessKeyId: options.accessKey,
@@ -143,7 +146,11 @@ S3Adapter.prototype.getFileData = function(filename) {
 // The location is the direct S3 link if the option is set, otherwise we serve the file through parse-server
 S3Adapter.prototype.getFileLocation = function(config, filename) {
   if (this._directAccess) {
-    return `https://${this._bucket}.s3.amazonaws.com/${this._bucketPrefix + filename}`;
+    if (this._baseUrl) {
+      return `${this._baseUrl}/${this._bucketPrefix + filename}`;
+    } else {
+      return `https://${this._bucket}.s3.amazonaws.com/${this._bucketPrefix + filename}`;
+    }
   }
   return (config.mount + '/files/' + config.applicationId + '/' + encodeURIComponent(filename));
 }

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -40,6 +40,11 @@ describe('S3Adapter tests', () => {
     expect(s3._region).toBe('us-east-1');
     expect(s3.getFileLocation({}, 'file.txt')).toEqual('https://myBucket.s3.amazonaws.com/file.txt')
 
+    s3 = new S3Adapter('accessKey', 'secretKey', 'myBucket', {directAccess: true, baseUrl: 'http://images.example.com'});
+    expect(s3._directAccess).toBe(true);
+    expect(s3._region).toBe('us-east-1');
+    expect(s3.getFileLocation({}, 'file.txt')).toEqual('http://images.example.com/file.txt')
+
     s3 = new S3Adapter({'accessKey':'accessKey', 'secretKey': 'secretKey', 'bucket': 'myBucket', directAccess: false, 'region': 'us-east-2'});
     expect(s3._directAccess).toBe(false);
     expect(s3._region).toBe('us-east-2');


### PR DESCRIPTION
The option is optionally, based on the requirement from https://github.com/ParsePlatform/parse-server/issues/792

