### PR TITLE
Adding ability to ignore bucketPrefix for public URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ parse-server adapter for AWS S3
       "region": 'us-east-1', // default value
       "bucketPrefix": '', // default value
       "directAccess": false, // default value
-      "baseUrl": null // default value
+      "baseUrl": null, // default value
+      "baseUrlDirect": false // default value
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ function optionsFromArguments(args) {
       options.bucketPrefix = otherOptions.bucketPrefix;
       options.directAccess = otherOptions.directAccess;
       options.baseUrl = otherOptions.baseUrl;
+      options.baseUrlDirect = otherOptions.baseUrlDirect;
     }
   } else {
     options = accessKeyOrOptions || {};
@@ -42,6 +43,8 @@ function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'region', 'S3_REGION', DEFAULT_S3_REGION);
   options = fromEnvironmentOrDefault(options, 'directAccess', 'S3_DIRECT_ACCESS', false);
   options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
+  options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
+
   return options;
 }
 
@@ -55,6 +58,7 @@ function S3Adapter() {
   this._bucketPrefix = options.bucketPrefix;
   this._directAccess = options.directAccess;
   this._baseUrl = options.baseUrl;
+  this._baseUrlDirect = options.baseUrlDirect;
 
   let s3Options = {
     accessKeyId: options.accessKey,
@@ -146,7 +150,9 @@ S3Adapter.prototype.getFileData = function(filename) {
 // The location is the direct S3 link if the option is set, otherwise we serve the file through parse-server
 S3Adapter.prototype.getFileLocation = function(config, filename) {
   if (this._directAccess) {
-    if (this._baseUrl) {
+    if (this._baseUrl && this._baseUrlDirect) {
+      return `${this._baseUrl}/${filename}`;
+    } else if (this._baseUrl) {
       return `${this._baseUrl}/${this._bucketPrefix + filename}`;
     } else {
       return `https://${this._bucket}.s3.amazonaws.com/${this._bucketPrefix + filename}`;


### PR DESCRIPTION
This adds ``baseUrlDirect`` Which will ignore bucketPrefix when generating URLs