### PR TITLE
get signature version from environment or default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ parse-server adapter for AWS S3
       "bucketPrefix": '', // default value
       "directAccess": false, // default value
       "baseUrl": null, // default value
-      "baseUrlDirect": false // default value
+      "baseUrlDirect": false, // default value
+      "signatureVersion": 'v4' // default value
     }
   }
 }
@@ -42,6 +43,7 @@ Set your environment variables:
 S3_ACCESS_KEY=accessKey
 S3_SECRET_KEY=secretKey
 S3_BUCKET=bucketName
+S3_SIGNATURE_VERSION=v4
 ```
 
 And update your config / options
@@ -67,7 +69,8 @@ var s3Adapter = new S3Adapter('accessKey',
                     region: 'us-east-1'
                     bucketPrefix: '',
                     directAccess: false,
-                    baseUrl: 'http://images.example.com'
+                    baseUrl: 'http://images.example.com',
+                    signatureVersion: 'v4'
                   });
 
 var api = new ParseServer({
@@ -90,7 +93,8 @@ var s3Options = {
   "region": 'us-east-1', // default value
   "bucketPrefix": '', // default value
   "directAccess": false, // default value
-  "baseUrl": null // default value
+  "baseUrl": null // default value,
+  "signatureVersion": 'v4' // default value
 }
 
 var s3Adapter = new S3Adapter(s3Options);

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ function optionsFromArguments(args) {
       options.directAccess = otherOptions.directAccess;
       options.baseUrl = otherOptions.baseUrl;
       options.baseUrlDirect = otherOptions.baseUrlDirect;
+      options.signatureVersion = otherOptions.signatureVersion;
     }
   } else {
     options = accessKeyOrOptions || {};
@@ -44,6 +45,7 @@ function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'directAccess', 'S3_DIRECT_ACCESS', false);
   options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
   options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
+  options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
 
   return options;
 }
@@ -59,12 +61,14 @@ function S3Adapter() {
   this._directAccess = options.directAccess;
   this._baseUrl = options.baseUrl;
   this._baseUrlDirect = options.baseUrlDirect;
+  this._signatureVersion = options.signatureVersion;
 
   let s3Options = {
     accessKeyId: options.accessKey,
     secretAccessKey: options.secretKey,
     params: { Bucket: this._bucket },
-    region: this._region
+    region: this._region,
+    signatureVersion: this._signatureVersion
   };
   this._s3Client = new AWS.S3(s3Options);
   this._hasBucket = false;


### PR DESCRIPTION
#5 fixes signature version issue. Signature version can be given while creating s3 object or from environment variable. Default signature version is set to v4