### PR TITLE
Add an optional global cache control for all s3 uploaded files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ parse-server adapter for AWS S3
       "directAccess": false, // default value
       "baseUrl": null, // default value
       "baseUrlDirect": false, // default value
-      "signatureVersion": 'v4' // default value
+      "signatureVersion": 'v4', // default value
+      "globalCacheControl": null // default value. Or 'public, max-age=86400000' for 24 hrs Cache-Control
     }
   }
 }
@@ -70,7 +71,8 @@ var s3Adapter = new S3Adapter('accessKey',
                     bucketPrefix: '',
                     directAccess: false,
                     baseUrl: 'http://images.example.com',
-                    signatureVersion: 'v4'
+                    signatureVersion: 'v4',
+                    globalCacheControl: 'public, max-age=86400000'  // 24 hrs Cache-Control.
                   });
 
 var api = new ParseServer({
@@ -94,7 +96,8 @@ var s3Options = {
   "bucketPrefix": '', // default value
   "directAccess": false, // default value
   "baseUrl": null // default value,
-  "signatureVersion": 'v4' // default value
+  "signatureVersion": 'v4', // default value
+  "globalCacheControl": null // default value. Or 'public, max-age=86400000' for 24 hrs Cache-Control
 }
 
 var s3Adapter = new S3Adapter(s3Options);

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ function optionsFromArguments(args) {
       options.baseUrl = otherOptions.baseUrl;
       options.baseUrlDirect = otherOptions.baseUrlDirect;
       options.signatureVersion = otherOptions.signatureVersion;
+      options.globalCacheControl = otherOptions.globalCacheControl;
     }
   } else {
     options = accessKeyOrOptions || {};
@@ -46,6 +47,7 @@ function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
   options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
   options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
+  options = fromEnvironmentOrDefault(options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
 
   return options;
 }
@@ -62,13 +64,15 @@ function S3Adapter() {
   this._baseUrl = options.baseUrl;
   this._baseUrlDirect = options.baseUrlDirect;
   this._signatureVersion = options.signatureVersion;
+  this._globalCacheControl = options.globalCacheControl;
 
   let s3Options = {
     accessKeyId: options.accessKey,
     secretAccessKey: options.secretKey,
     params: { Bucket: this._bucket },
     region: this._region,
-    signatureVersion: this._signatureVersion
+    signatureVersion: this._signatureVersion,
+    globalCacheControl: this._globalCacheControl
   };
   this._s3Client = new AWS.S3(s3Options);
   this._hasBucket = false;
@@ -101,6 +105,9 @@ S3Adapter.prototype.createFile = function(filename, data, contentType) {
   }
   if (contentType) {
     params.ContentType = contentType;
+  }
+  if(this._globalCacheControl) {
+    params.CacheControl = this._globalCacheControl;
   }
   return this.createBucket().then(() => {
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Usage Example:
.
.
filesAdapter: new S3Adapter(
    process.env.S3_ACCESS_KEY || "ABCD...",
    process.env.S3_SECRET_KEY || "AbCD+EF...",
    process.env.S3_BUCKET || "some-bucket-name",
    {
	directAccess: true,
	bucketPrefix: process.env.S3_BUCKET_PREFIX || 'optional-dir-name/',
	region: process.env.S3_REGION || 'us-east-1',
        baseUrl: 'https://files.example.com'
        globalCacheControl: 'public, max-age=86400000'  // 24 hrs Cache-Control.
    }
)