### PR TITLE
Use default AWS credential provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ parse-server adapter for AWS S3
 
 `npm install --save parse-server-s3-adapter`
 
+# aws credentials
+
+AWS credentials can be explicitly configured through an options object or environment variables.
+
+If no AWS credentials are configured, the AWS SDK will look for credentials in the standard locations used by all AWS SDKs and the AWS CLI. More info can be found in [the docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
+
 # usage with parse-server
 
 ### using a config file
@@ -20,10 +26,10 @@ parse-server adapter for AWS S3
   "filesAdapter": {
     "module": "parse-server-s3-adapter",
     "options": {
-      "accessKey": "accessKey",
-      "secretKey": "secretKey",
       "bucket": "my_bucket",
       // optional:
+      "accessKey": "accessKey",
+      "secretKey": "secretKey",
       "region": 'us-east-1', // default value
       "bucketPrefix": '', // default value
       "directAccess": false, // default value
@@ -64,9 +70,8 @@ And update your config / options
 ```
 var S3Adapter = require('parse-server-s3-adapter');
 
-var s3Adapter = new S3Adapter('accessKey',
-                  'secretKey',
-                  'bucket' , {
+var s3Adapter = new S3Adapter('bucket', ['accessKey',
+                  'secretKey',] {
                     region: 'us-east-1'
                     bucketPrefix: '',
                     directAccess: false,
@@ -88,14 +93,14 @@ or with an options hash
 var S3Adapter = require('parse-server-s3-adapter');
 
 var s3Options = {
-  "accessKey": "accessKey",
-  "secretKey": "secretKey",
   "bucket": "my_bucket",
   // optional:
+  "accessKey": null, // default value
+  "secretKey": null, // default value
   "region": 'us-east-1', // default value
   "bucketPrefix": '', // default value
   "directAccess": false, // default value
-  "baseUrl": null // default value,
+  "baseUrl": null // default value
   "signatureVersion": 'v4', // default value
   "globalCacheControl": null // default value. Or 'public, max-age=86400000' for 24 hrs Cache-Control
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ parse-server adapter for AWS S3
 
 # aws credentials
 
-AWS credentials can be explicitly configured through an options object or environment variables ([see below](#using-a-config-file)).
+AWS credentials can be explicitly configured through an options object, constructor string arguments or environment variables ([see below](#using-a-config-file)).
 
 If no AWS credentials are configured, the AWS SDK will look for credentials in the standard locations used by all AWS SDKs and the AWS CLI. More info can be found in [the docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
 
@@ -66,7 +66,6 @@ And update your config / options
 
 
 ### passing as an instance
-
 ```
 var S3Adapter = require('parse-server-s3-adapter');
 
@@ -85,6 +84,15 @@ var api = new ParseServer({
 	masterKey: 'master_key',
 	filesAdapter: s3adapter
 })
+```
+**Note:** there are a few ways you can pass arguments:
+
+```
+S3Adapter("bucket")
+S3Adapter("bucket", options)
+S3Adapter("key", "secret", "bucket")
+S3Adapter("key", "secret", "bucket", options)
+S3Adapter(options) // where options must contain bucket.
 ```
 
 or with an options hash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ parse-server adapter for AWS S3
 
 # aws credentials
 
-AWS credentials can be explicitly configured through an options object or environment variables.
+AWS credentials can be explicitly configured through an options object or environment variables ([see below](#using-a-config-file)).
 
 If no AWS credentials are configured, the AWS SDK will look for credentials in the standard locations used by all AWS SDKs and the AWS CLI. More info can be found in [the docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ parse-server adapter for AWS S3
 
 # aws credentials
 
-AWS credentials can be explicitly configured through an options object, constructor string arguments or environment variables ([see below](#using-a-config-file)).
+Although it is not recommended, AWS credentials can be explicitly configured through an options
+object, constructor string arguments or environment variables ([see below](#using-a-config-file)).
+This option is provided for backward compatibility.
 
-If no AWS credentials are configured, the AWS SDK will look for credentials in the standard locations used by all AWS SDKs and the AWS CLI. More info can be found in [the docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
+The preferred method is to use the default AWS credentials pattern.  If no AWS credentials are explicitly configured, the AWS SDK will look for credentials in the standard locations used by all AWS SDKs and the AWS CLI. More info can be found in [the docs](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).  For more information on AWS best practices, see [IAM Best Practices User Guide](http://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html).
 
 # usage with parse-server
 
@@ -47,9 +49,14 @@ If no AWS credentials are configured, the AWS SDK will look for credentials in t
 Set your environment variables:
 
 ```
+S3_BUCKET=bucketName
+```
+
+the following optional configurations can be set by environment variables too:
+
+```
 S3_ACCESS_KEY=accessKey
 S3_SECRET_KEY=secretKey
-S3_BUCKET=bucketName
 S3_SIGNATURE_VERSION=v4
 ```
 
@@ -69,8 +76,8 @@ And update your config / options
 ```
 var S3Adapter = require('parse-server-s3-adapter');
 
-var s3Adapter = new S3Adapter('bucket', ['accessKey',
-                  'secretKey',] {
+var s3Adapter = new S3Adapter(['accessKey',
+                  'secretKey',] bucket, {
                     region: 'us-east-1'
                     bucketPrefix: '',
                     directAccess: false,

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ And update your config / options
 ```
 var S3Adapter = require('parse-server-s3-adapter');
 
-var s3Adapter = new S3Adapter(['accessKey',
-                  'secretKey',] bucket, {
+var s3Adapter = new S3Adapter('accessKey',
+                  'secretKey', bucket, {
                     region: 'us-east-1'
                     bucketPrefix: '',
                     directAccess: false,

--- a/index.js
+++ b/index.js
@@ -4,54 +4,7 @@
 // Stores Parse files in AWS S3.
 
 var AWS = require('aws-sdk');
-const DEFAULT_S3_REGION = "us-east-1";
-
-function requiredOrFromEnvironment(options, key, env) {
-  options[key] = options[key] || process.env[env];
-  if (!options[key]) {
-    throw `S3Adapter requires option '${key}' or env. variable ${env}`;
-  }
-  return options;
-}
-
-function fromEnvironmentOrDefault(options, key, env, defaultValue) {
-  options[key] = options[key] || process.env[env] || defaultValue;
-  return options;
-}
-
-function optionsFromArguments(args) {
-  let options = {};
-  let bucketOrOptions = args[0];
-  if (typeof bucketOrOptions == 'string') {
-    options.bucket = bucketOrOptions;
-    options.accessKey = args[1];
-    options.secretKey = args[2];
-    let otherOptions = args[3];
-    if (otherOptions) {
-      options.bucketPrefix = otherOptions.bucketPrefix;
-      options.directAccess = otherOptions.directAccess;
-      options.baseUrl = otherOptions.baseUrl;
-      options.baseUrlDirect = otherOptions.baseUrlDirect;
-      options.signatureVersion = otherOptions.signatureVersion;
-      options.globalCacheControl = otherOptions.globalCacheControl;
-    }
-  } else {
-    options = bucketOrOptions || {};
-  }
-  options = requiredOrFromEnvironment(options, 'bucket', 'S3_BUCKET');
-  options = fromEnvironmentOrDefault(options, 'accessKey', 'S3_ACCESS_KEY', null);
-  options = fromEnvironmentOrDefault(options, 'secretKey', 'S3_SECRET_KEY', null);
-  options = fromEnvironmentOrDefault(options, 'bucketPrefix', 'S3_BUCKET_PREFIX', '');
-  options = fromEnvironmentOrDefault(options, 'region', 'S3_REGION', DEFAULT_S3_REGION);
-  options = fromEnvironmentOrDefault(options, 'directAccess', 'S3_DIRECT_ACCESS', false);
-  options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
-  options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
-  options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
-  options = fromEnvironmentOrDefault(
-    options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
-
-  return options;
-}
+var optionsFromArguments = require('./lib/optionsFromArguments');
 
 // Creates an S3 session.
 // Providing AWS access, secret keys and bucket are mandatory

--- a/index.js
+++ b/index.js
@@ -21,11 +21,11 @@ function fromEnvironmentOrDefault(options, key, env, defaultValue) {
 
 function optionsFromArguments(args) {
   let options = {};
-  let accessKeyOrOptions = args[0];
-  if (typeof accessKeyOrOptions == 'string') {
-    options.accessKey = accessKeyOrOptions;
-    options.secretKey = args[1];
-    options.bucket = args[2];
+  let bucketOrOptions = args[0];
+  if (typeof bucketOrOptions == 'string') {
+    options.bucket = bucketOrOptions;
+    options.accessKey = args[1];
+    options.secretKey = args[2];
     let otherOptions = args[3];
     if (otherOptions) {
       options.bucketPrefix = otherOptions.bucketPrefix;
@@ -36,18 +36,19 @@ function optionsFromArguments(args) {
       options.globalCacheControl = otherOptions.globalCacheControl;
     }
   } else {
-    options = accessKeyOrOptions || {};
+    options = bucketOrOptions || {};
   }
-  options = requiredOrFromEnvironment(options, 'accessKey', 'S3_ACCESS_KEY');
-  options = requiredOrFromEnvironment(options, 'secretKey', 'S3_SECRET_KEY');
   options = requiredOrFromEnvironment(options, 'bucket', 'S3_BUCKET');
+  options = fromEnvironmentOrDefault(options, 'accessKey', 'S3_ACCESS_KEY', null);
+  options = fromEnvironmentOrDefault(options, 'secretKey', 'S3_SECRET_KEY', null);
   options = fromEnvironmentOrDefault(options, 'bucketPrefix', 'S3_BUCKET_PREFIX', '');
   options = fromEnvironmentOrDefault(options, 'region', 'S3_REGION', DEFAULT_S3_REGION);
   options = fromEnvironmentOrDefault(options, 'directAccess', 'S3_DIRECT_ACCESS', false);
   options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
   options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
   options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
-  options = fromEnvironmentOrDefault(options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
+  options = fromEnvironmentOrDefault(
+    options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
 
   return options;
 }
@@ -67,13 +68,17 @@ function S3Adapter() {
   this._globalCacheControl = options.globalCacheControl;
 
   let s3Options = {
-    accessKeyId: options.accessKey,
-    secretAccessKey: options.secretKey,
     params: { Bucket: this._bucket },
     region: this._region,
     signatureVersion: this._signatureVersion,
     globalCacheControl: this._globalCacheControl
   };
+
+  if (options.accessKey && options.secretKey) {
+    options.accessKeyId = options.accessKey;
+    options.secretAccessKey = options.secretKey;
+  }
+
   this._s3Client = new AWS.S3(s3Options);
   this._hasBucket = false;
 }
@@ -147,7 +152,7 @@ S3Adapter.prototype.getFileData = function(filename) {
         if (err !== null) {
           return reject(err);
         }
-        // Something happend here...
+        // Something happened here...
         if (data && !data.Body) {
           return reject(data);
         }

--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const DEFAULT_S3_REGION = 'us-east-1';
+
+function requiredOrFromEnvironment(options, key, env) {
+  options[key] = options[key] || process.env[env];
+  if (!options[key]) {
+    throw `S3Adapter requires option '${key}' or env. variable ${env}`;
+  }
+  return options;
+}
+
+function fromEnvironmentOrDefault(options, key, env, defaultValue) {
+  options[key] = options[key] || process.env[env] || defaultValue;
+  return options;
+}
+
+const optionsFromArguments = function optionsFromArguments(args) {
+  const stringOrOptions = args[0];
+  let options = {};
+  let otherOptions;
+
+  if (typeof stringOrOptions == 'string') {
+    if (args.length == 1) {
+      options.bucket = stringOrOptions;
+    } else if (args.length == 2) {
+      options.bucket = stringOrOptions;
+      if (typeof args[1] != 'object') {
+        throw new Error(`Failed to configure S3Adapter.  Argument ${args[0]} & ${args[1]}` +
+          ` don't make sense`);
+      }
+      otherOptions = args[1];
+    } else if (args.length > 2) {
+      if (typeof args[1] != 'string' || typeof args[2] != 'string') {
+        throw new Error(`Failed to configure S3Adapter. Arguments ${args[1]} & ${args[2]}` +
+          ` don't make sense`);
+      }
+      options.accessKey = args[0];
+      options.secretKey = args[1];
+      options.bucket = args[2];
+      otherOptions = args[3];
+    }
+
+    if (otherOptions) {
+      options.bucketPrefix = otherOptions.bucketPrefix;
+      options.directAccess = otherOptions.directAccess;
+      options.baseUrl = otherOptions.baseUrl;
+      options.baseUrlDirect = otherOptions.baseUrlDirect;
+      options.signatureVersion = otherOptions.signatureVersion;
+      options.globalCacheControl = otherOptions.globalCacheControl;
+    }
+  } else {
+    options = stringOrOptions || {};
+  }
+  options = requiredOrFromEnvironment(options, 'bucket', 'S3_BUCKET');
+  options = fromEnvironmentOrDefault(options, 'accessKey', 'S3_ACCESS_KEY', null);
+  options = fromEnvironmentOrDefault(options, 'secretKey', 'S3_SECRET_KEY', null);
+  options = fromEnvironmentOrDefault(options, 'bucketPrefix', 'S3_BUCKET_PREFIX', '');
+  options = fromEnvironmentOrDefault(options, 'region', 'S3_REGION', DEFAULT_S3_REGION);
+  options = fromEnvironmentOrDefault(options, 'directAccess', 'S3_DIRECT_ACCESS', false);
+  options = fromEnvironmentOrDefault(options, 'baseUrl', 'S3_BASE_URL', null);
+  options = fromEnvironmentOrDefault(options, 'baseUrlDirect', 'S3_BASE_URL_DIRECT', false);
+  options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
+  options = fromEnvironmentOrDefault(
+    options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
+
+  return options;
+}
+
+module.exports = optionsFromArguments;

--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -26,14 +26,12 @@ const optionsFromArguments = function optionsFromArguments(args) {
     } else if (args.length == 2) {
       options.bucket = stringOrOptions;
       if (typeof args[1] != 'object') {
-        throw new Error(`Failed to configure S3Adapter.  Argument ${args[0]} & ${args[1]}` +
-          ` don't make sense`);
+        throw new Error('Failed to configure S3Adapter. Arguments don\'t make sense');
       }
       otherOptions = args[1];
     } else if (args.length > 2) {
       if (typeof args[1] != 'string' || typeof args[2] != 'string') {
-        throw new Error(`Failed to configure S3Adapter. Arguments ${args[1]} & ${args[2]}` +
-          ` don't make sense`);
+        throw new Error('Failed to configure S3Adapter. Arguments don\'t make sense');
       }
       options.accessKey = args[0];
       options.secretKey = args[1];

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -11,7 +11,7 @@ describe('S3Adapter tests', () => {
     }).toThrow("S3Adapter requires option 'bucket' or env. variable S3_BUCKET")
 
     expect(() => {
-      var s3 = new S3Adapter('accessKey', 'secretKey');
+      var s3 = new S3Adapter(null, 'accessKey', 'secretKey');
     }).toThrow("S3Adapter requires option 'bucket' or env. variable S3_BUCKET")
 
     expect(() => {
@@ -64,7 +64,7 @@ describe('S3Adapter tests', () => {
 
     it('should go directly to amazon', () => {
       delete options.baseUrl;
-      var s3 = new S3Adapter('accessKey', 'secretKey', 'myBucket', options);
+      var s3 = new S3Adapter('myBucket', 'accessKey', 'secretKey', options);
       expect(s3.getFileLocation(config, 'test.png')).toEqual('https://myBucket.s3.amazonaws.com/foo/bar/test.png');
     });
   });

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -13,7 +13,7 @@ describe('S3Adapter tests', () => {
 
     expect(() =>  {
       var s3 = new S3Adapter('accessKey', 'secretKey', {});
-    }).toThrow();
+    }).toThrow(new Error('Failed to configure S3Adapter. Arguments don\'t make sense'));
 
     expect(() => {
       var s3 = new S3Adapter({ accessKey: 'accessKey' , secretKey: 'secretKey'});

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -8,19 +8,12 @@ describe('S3Adapter tests', () => {
   it('should throw when not initialized properly', () => {
     expect(() => {
       var s3 = new S3Adapter();
-    }).toThrow("S3Adapter requires option 'accessKey' or env. variable S3_ACCESS_KEY")
-
-    expect(() => {
-      var s3 = new S3Adapter('accessKey');
-    }).toThrow("S3Adapter requires option 'secretKey' or env. variable S3_SECRET_KEY")
+    }).toThrow("S3Adapter requires option 'bucket' or env. variable S3_BUCKET")
 
     expect(() => {
       var s3 = new S3Adapter('accessKey', 'secretKey');
     }).toThrow("S3Adapter requires option 'bucket' or env. variable S3_BUCKET")
 
-    expect(() => {
-      var s3 = new S3Adapter({ accessKey: 'accessKey'});
-    }).toThrow("S3Adapter requires option 'secretKey' or env. variable S3_SECRET_KEY")
     expect(() => {
       var s3 = new S3Adapter({ accessKey: 'accessKey' , secretKey: 'secretKey'});
     }).toThrow("S3Adapter requires option 'bucket' or env. variable S3_BUCKET")
@@ -28,11 +21,11 @@ describe('S3Adapter tests', () => {
 
   it('should not throw when initialized properly', () => {
     expect(() => {
-      var s3 = new S3Adapter('accessKey', 'secretKey', 'bucket');
+      var s3 = new S3Adapter('bucket');
     }).not.toThrow()
 
     expect(() => {
-      var s3 = new S3Adapter({ accessKey: 'accessKey' , secretKey: 'secretKey', bucket: 'bucket'});
+      var s3 = new S3Adapter({ bucket: 'bucket'});
     }).not.toThrow()
   });
 


### PR DESCRIPTION
The changes allows the s3 adapter to pick up ec2 roles which is AWS best practice and eliminates the need to distribute keys at all (see: http://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#use-roles-with-ec2).

* Make key and secret optional
* Move arg processing to own module to facilitate unit testing
* Alter spec for optional credentials
* Update README

fixes: #14 