### PR TITLE
Fix bug that put credentials on the wrong object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ function S3Adapter() {
   };
 
   if (options.accessKey && options.secretKey) {
-    options.accessKeyId = options.accessKey;
-    options.secretAccessKey = options.secretKey;
+    s3Options.accessKeyId = options.accessKey;
+    s3Options.secretAccessKey = options.secretKey;
   }
 
   this._s3Client = new AWS.S3(s3Options);


### PR DESCRIPTION
my $.02: this bug, though clearly my error, demonstrates why using non-standard env vars is not a good idea.  In order for me to fully test, I have to unset my standard env vars:
```
AWS_ACCESS_KEY_ID
AWS_DEFAULT_REGION
AWS_SECRET_ACCESS_KEY
```
and also move my (redundant) ```~/.aws``` config dir.

My suggestion is that this adapter should get a major revision bump that removes the paramters for access key and secret while maintaining the ability to pass them in config object.  But in the case that they are passed in the config object they should have the same name that the lib expects: ```accessKeyId``` and ```secretAccessKey```.

The two advantages of making this breaking change:

1. promotes use of best security practices from the get go for a new user.
2. removes an unnecessary and somewhat difficult wrinkle in testing. 