### PR TITLE
Use baseUrl as S3 endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ function S3Adapter() {
   let s3Options = {
     params: { Bucket: this._bucket },
     region: this._region,
+    endpoint: this._baseUrl,
+    s3BucketEndpoint: !!this._baseUrl,
     signatureVersion: this._signatureVersion,
     globalCacheControl: this._globalCacheControl
   };


### PR DESCRIPTION
Normally, S3 uses urls like `https://{service}.{region}.amazonaws.com` as endpoint for their S3 library. This works fine when one is actually using the Amazon S3 service.

However, we are using an Amazon S3 compatible object storage system provided by Scalingo instead. Here, the endpoint is `https://s3.myagora.fr/<bucket>`. We need to be able to somehow specify that endpoint in the s3 file adapter.

This PR uses the already available `baseUrl` parameter as endpoint if provided. The option `s3BucketEndpoint` is needed to stop the S3 lib from adding a `bucket.` subdomain (see [the official aws docs](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property) for more info).

If the behavioral change of this PR is causing problems (I couldn't think of any so far), we'd alternatively be happy with a separate configuration option for the endpoint.