### PR TITLE
Add s3overrides option format

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ S3Adapter("bucket", options)
 S3Adapter("key", "secret", "bucket")
 S3Adapter("key", "secret", "bucket", options)
 S3Adapter(options) // where options must contain bucket.
+S3Adapter(options, s3overrides)
 ```
+If you use the last form, `s3overrides` are the parameters passed to [AWS.S3](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property).
+
+In this form if you set `s3overrides.params`, you must set at least `s3overrides.params.Bucket`
 
 or with an options hash
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,8 @@ function S3Adapter() {
     s3Options.secretAccessKey = options.secretKey;
   }
 
+  Object.assign(s3Options, options.s3overrides);
+
   this._s3Client = new AWS.S3(s3Options);
   this._hasBucket = false;
 }

--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -18,6 +18,7 @@ function fromEnvironmentOrDefault(options, key, env, defaultValue) {
 const optionsFromArguments = function optionsFromArguments(args) {
   const stringOrOptions = args[0];
   let options = {};
+  let s3overrides = {};
   let otherOptions;
 
   if (typeof stringOrOptions == 'string') {
@@ -48,7 +49,15 @@ const optionsFromArguments = function optionsFromArguments(args) {
       options.globalCacheControl = otherOptions.globalCacheControl;
     }
   } else {
-    options = stringOrOptions || {};
+    if (args.length == 1) {
+      options = stringOrOptions || {};
+    } else if (args.length == 2) {
+      options = stringOrOptions;
+      s3overrides = args[1];
+      options.bucket = s3overrides.params.Bucket;
+    } else {
+      throw new Error('Failed to configure S3Adapter. Arguments don\'t make sense');
+    }
   }
   options = requiredOrFromEnvironment(options, 'bucket', 'S3_BUCKET');
   options = fromEnvironmentOrDefault(options, 'accessKey', 'S3_ACCESS_KEY', null);
@@ -61,6 +70,7 @@ const optionsFromArguments = function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
   options = fromEnvironmentOrDefault(
     options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
+  options.s3overrides = s3overrides;
 
   return options;
 }

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -9,7 +9,7 @@ describe('S3Adapter tests', () => {
   it('should throw when not initialized properly', () => {
     expect(() => {
       var s3 = new S3Adapter();
-    }).toThrow("S3Adapter requires option 'bucket' or env. variable S3_BUCKET")
+    }).toThrow(new Error('Failed to configure S3Adapter. Arguments don\'t make sense'));
 
     expect(() =>  {
       var s3 = new S3Adapter('accessKey', 'secretKey', {});
@@ -27,6 +27,10 @@ describe('S3Adapter tests', () => {
 
     expect(() => {
       var s3 = new S3Adapter({ bucket: 'bucket'});
+    }).not.toThrow()
+
+    expect(() => {
+      var s3 = new S3Adapter({}, { params:{ Bucket: 'bucket'}});
     }).not.toThrow()
   });
 
@@ -61,6 +65,16 @@ describe('S3Adapter tests', () => {
       expect(options.secretKey).toEqual('secret');
       expect(options.bucket).toEqual('bucket');
       expect(options.bucketPrefix).toEqual('test/');
+    });
+
+    it('should accept options and overrides as args', () => {
+      var confObj = { bucketPrefix: 'test/', bucket: 'bucket-1', secretKey: 'secret-1', accessKey: 'key-1' };
+      var overridesObj = { secretAccessKey: 'secret-2', accessKeyId: 'key-2', params: { Bucket: 'bucket-2' }};
+      var s3 = new S3Adapter(confObj, overridesObj);
+      expect(s3._s3Client.config.accessKeyId).toEqual('key-2');
+      expect(s3._s3Client.config.secretAccessKey).toEqual('secret-2');
+      expect(s3._s3Client.config.params.Bucket).toEqual('bucket-2');
+      expect(s3._bucketPrefix).toEqual('test/');
     });
   });
 


### PR DESCRIPTION
The goal of this change is to allow developers to specify any and all options permissible to the [AWS.S3](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#constructor-property) constructor. This is useful when working with other s3-compatible services since we may wish to override a number of options.

This new options format should not break any existing configurations. The downside of configuring this way is that [Object.assign()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) only works on the first level of the objects, so deeper items like `params.Bucket` could be masked.