### PR TITLE
Handle immutable configuration

### DIFF
--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -50,15 +50,16 @@ const optionsFromArguments = function optionsFromArguments(args) {
     }
   } else {
     if (args.length == 1) {
-      options = stringOrOptions || {};
+      Object.assign(options, stringOrOptions);
     } else if (args.length == 2) {
-      options = stringOrOptions;
+      Object.assign(options, stringOrOptions);
       s3overrides = args[1];
       options.bucket = s3overrides.params.Bucket;
-    } else {
+    } else if (args.length > 2) {
       throw new Error('Failed to configure S3Adapter. Arguments don\'t make sense');
     }
   }
+
   options = requiredOrFromEnvironment(options, 'bucket', 'S3_BUCKET');
   options = fromEnvironmentOrDefault(options, 'accessKey', 'S3_ACCESS_KEY', null);
   options = fromEnvironmentOrDefault(options, 'secretKey', 'S3_SECRET_KEY', null);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AWS S3 adapter for parse-server",
   "main": "index.js",
   "scripts": {
-    "test": "NODE_CONFIG_DIR=./spec/config istanbul cover -x **/spec/** jasmine --captureExceptions"
+    "test": "NODE_ENV=test NODE_CONFIG_DIR=./spec/config istanbul cover -x **/spec/** jasmine --captureExceptions"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AWS S3 adapter for parse-server",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover -x **/spec/** jasmine --captureExceptions"
+    "test": "NODE_CONFIG_DIR=./spec/config istanbul cover -x **/spec/** jasmine --captureExceptions"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "codecov": "^1.0.1",
+    "config": "^1.24.0",
     "istanbul": "^0.4.2",
     "jasmine": "^2.4.1",
     "parse-server-conformance-tests": "^1.0.0"

--- a/spec/config/test.js
+++ b/spec/config/test.js
@@ -1,0 +1,18 @@
+module.exports = {
+  accessKey: 'accessKey',
+  secretKey: 'secretKey',
+  insufficientOptions: {
+    accessKey: 'accessKey',
+    secretKey: 'secretKey',
+  },
+  bucket: 'bucket',
+  objectWithBucket: {
+      bucket: 'bucket',
+  },
+  emptyObject: {},
+  paramsObjectWBucket: {
+      params: {
+          Bucket: 'bucket',
+      },
+  },
+};

--- a/spec/helpers/testHelpers.js
+++ b/spec/helpers/testHelpers.js
@@ -1,0 +1,1 @@
+process.env.NODE_ENV = 'test';

--- a/spec/helpers/testHelpers.js
+++ b/spec/helpers/testHelpers.js
@@ -1,1 +1,0 @@
-process.env.NODE_ENV = 'test';

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,6 +1,9 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "test.spec.js"
-  ]
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+        "helpers/**/*.js"
+    ]
 }

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -8,7 +8,7 @@ const optionsFromArguments = require('../lib/optionsFromArguments');
 describe('S3Adapter tests', () => {
   beforeEach(() => {
     delete process.env.S3_BUCKET;
-    delete process.env.S3_REGION
+    delete process.env.S3_REGION;
   });
 
   it('should throw when not initialized properly', () => {


### PR DESCRIPTION
The popular and awesome https://github.com/lorenwest/node-config
makes all configs values immutable.  Good practice!

parse-server-s3-adapter attempts to edit config values.

This fix will respect immutability allowing this adapter
to work with node-config.