### PR TITLE
allowing empty params in overrides

### DIFF
--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -54,7 +54,10 @@ const optionsFromArguments = function optionsFromArguments(args) {
     } else if (args.length == 2) {
       Object.assign(options, stringOrOptions);
       s3overrides = args[1];
-      options.bucket = s3overrides.params.Bucket;
+
+      if (s3overrides.params) {
+        options.bucket = s3overrides.params.Bucket;
+      }
     } else if (args.length > 2) {
       throw new Error('Failed to configure S3Adapter. Arguments don\'t make sense');
     }

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -132,6 +132,16 @@ describe('S3Adapter tests', () => {
       expect(s3._s3Client.config.params.Bucket).toEqual('bucket-2');
       expect(s3._bucketPrefix).toEqual('test/');
     });
+
+    it('should accept overrides without params', () => {
+      var confObj = { bucketPrefix: 'test/', bucket: 'bucket-1', secretKey: 'secret-1', accessKey: 'key-1' };
+      var overridesObj = { secretAccessKey: 'secret-2'};
+      var s3 = new S3Adapter(confObj, overridesObj);
+      expect(s3._s3Client.config.accessKeyId).toEqual('key-1');
+      expect(s3._s3Client.config.secretAccessKey).toEqual('secret-2');
+      expect(s3._s3Client.config.params.Bucket).toEqual('bucket-1');
+      expect(s3._bucketPrefix).toEqual('test/');
+    });
   });
 
   describe('getFileLocation', () => {


### PR DESCRIPTION
PR #24 introduced the option to add s3 overrides. According to documentation I have to set at least the `Bucket` *if* I set the `params` field. However, if I completely leave out the `params` field the adapter crashes. This PR fixes that.

This also enables the alternative fix proposed by @mrmarcsmith in PR #23 after the latter was reverted (sorry for breaking behavior there btw).