### PR TITLE
S3 overrides as option

### DIFF
--- a/lib/optionsFromArguments.js
+++ b/lib/optionsFromArguments.js
@@ -12,6 +12,20 @@ function requiredOrFromEnvironment(options, key, env) {
 
 function fromEnvironmentOrDefault(options, key, env, defaultValue) {
   options[key] = options[key] || process.env[env] || defaultValue;
+  // If we used the overrides,
+  // make sure they take priority
+  if(options.s3overrides){
+    if(options.s3overrides[key]){
+      options[key] = options.s3overrides[key];
+    }else if (options.s3overrides.params && options.s3overrides.params.Bucket) {
+      options.bucket = options.s3overrides.params.Bucket;
+    }
+  }
+  return options;
+}
+
+function fromOptionsDictionaryOrDefault(options, key, defaultValue) {
+  options[key] = options[key] || defaultValue;
   return options;
 }
 
@@ -64,6 +78,7 @@ const optionsFromArguments = function optionsFromArguments(args) {
     }
   }
 
+  options = fromOptionsDictionaryOrDefault(options, 's3overrides', s3overrides);
   options = requiredOrFromEnvironment(options, 'bucket', 'S3_BUCKET');
   options = fromEnvironmentOrDefault(options, 'accessKey', 'S3_ACCESS_KEY', null);
   options = fromEnvironmentOrDefault(options, 'secretKey', 'S3_SECRET_KEY', null);
@@ -75,7 +90,6 @@ const optionsFromArguments = function optionsFromArguments(args) {
   options = fromEnvironmentOrDefault(options, 'signatureVersion', 'S3_SIGNATURE_VERSION', 'v4');
   options = fromEnvironmentOrDefault(
     options, 'globalCacheControl', 'S3_GLOBAL_CACHE_CONTROL', null);
-  options.s3overrides = s3overrides;
 
   return options;
 }

--- a/spec/test.spec.js
+++ b/spec/test.spec.js
@@ -123,6 +123,15 @@ describe('S3Adapter tests', () => {
       expect(options.bucketPrefix).toEqual('test/');
     });
 
+    it('should accept options and overrides as an option in args', () => {
+      var confObj = { bucketPrefix: 'test/', bucket: 'bucket-1', secretKey: 'secret-1', accessKey: 'key-1' ,s3overrides: { secretAccessKey: 'secret-2', accessKeyId: 'key-2', params: { Bucket: 'bucket-2' }} };
+      var s3 = new S3Adapter(confObj);
+      expect(s3._s3Client.config.accessKeyId).toEqual('key-2');
+      expect(s3._s3Client.config.secretAccessKey).toEqual('secret-2');
+      expect(s3._s3Client.config.params.Bucket).toEqual('bucket-2');
+      expect(s3._bucketPrefix).toEqual('test/');
+    });
+
     it('should accept options and overrides as args', () => {
       var confObj = { bucketPrefix: 'test/', bucket: 'bucket-1', secretKey: 'secret-1', accessKey: 'key-1' };
       var overridesObj = { secretAccessKey: 'secret-2', accessKeyId: 'key-2', params: { Bucket: 'bucket-2' }};


### PR DESCRIPTION
This is the second attempt with cleaned up code. see #40 for the old PR

Background: when using parse server with a config file there is no way to specify S3Override options.
-This change doesn't affect the current method of passing s3overrides = backwards compatible.
-s3overrides would now be accessible by via parse-server config file like this:
```
"filesAdapter": {
    "module":"parse-server-s3-adapter",
    "options":{
        "s3overrides": { 
            "endpoint": {
                "protocol":"https:",
                "host":"$FILEURL",
                "port":443,
                "hostname":"",
                "pathname":"/",
                "path":"/",
                "href":"https:///"
            },
            "s3BucketEndpoint": false,
            ANY OTHER S3OVERRIDES GO HERE... 
        },
        "baseUrl": "https://",
        "directAccess": true,
        "accessKey": "",
        "secretKey": "",
        "bucket": "",
        "region": ""
    }
}
```